### PR TITLE
Support for Wagtail 2.9

### DIFF
--- a/wagtail_graphql/settings.py
+++ b/wagtail_graphql/settings.py
@@ -1,8 +1,11 @@
 # django
+from django import get_version
 from django.conf import settings
 # graphql
 from graphql import ResolveInfo
+from wagtail.core.models import Site
 
+DJANGO_VERSION = get_version()
 # settings
 if hasattr(settings, 'GRAPHQL_API'):
     SETTINGS = settings.GRAPHQL_API
@@ -20,7 +23,10 @@ except ImportError:  # pragma: no cover
 
 
 def url_prefix_for_site(info: ResolveInfo):
-    hostname = info.context.site.hostname
+    if DJANGO_VERSION < "2.2":
+        hostname = info.context.site.hostname
+    else:
+        hostname = Site.find_for_request(info.context).hostname
     return URL_PREFIX.get(
         hostname,
         info.context.site.root_page.url_path.rstrip('/')


### PR DESCRIPTION
These changes are to address deprecation of site from the WSGIRequest in Django 2.2.